### PR TITLE
Adding equation for updating liquidity position in case of partial withdrawal

### DIFF
--- a/hydradx/spec/WithdrawLiquidity.ipynb
+++ b/hydradx/spec/WithdrawLiquidity.ipynb
@@ -89,6 +89,21 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "62341c9e-3462-4098-b820-edcdaa4cd779",
+   "metadata": {},
+   "source": [
+    "### Updating NFT in case of partial withdraw\n",
+    "If $s_\\alpha + \\Delta s_\\alpha > 0$, the LP is only partially withdrawing their liquidity.\n",
+    "\n",
+    "Tracking the quantity of assets initially deposited is not required, but may be desirable for other reasons. Let us denote this quantity $r_\\alpha$.\n",
+    "Upon *partial* liquidity withdrawal, we recalculate $r_\\alpha$ as though the position is being split into two positions, and one entire position is being withdrawn.\n",
+    "$$\n",
+    "\\Delta r_\\alpha = r_\\alpha \\frac{\\Delta s_\\alpha}{s_\\alpha}\n",
+    "$$"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 2,
    "id": "d6482f4d-c498-44ec-a2d9-4cc5d72e79dd",

--- a/hydradx/spec/algebraic_checks/WithdrawLiquidity.ipynb
+++ b/hydradx/spec/algebraic_checks/WithdrawLiquidity.ipynb
@@ -75,6 +75,21 @@
   },
   {
    "cell_type": "markdown",
+   "id": "67db2d15-8691-41d0-955b-4b594fce1759",
+   "metadata": {},
+   "source": [
+    "### Updating NFT in case of partial withdraw\n",
+    "If $s_\\alpha + \\Delta s_\\alpha > 0$, the LP is only partially withdrawing their liquidity.\n",
+    "\n",
+    "Tracking the quantity of assets initially deposited is not required, but may be desirable for other reasons. Let us denote this quantity $r_\\alpha$.\n",
+    "Upon *partial* liquidity withdrawal, we recalculate $r_\\alpha$ as though the position is being split into two positions, and one entire position is being withdrawn.\n",
+    "$$\n",
+    "\\Delta r_\\alpha = r_\\alpha \\frac{\\Delta s_\\alpha}{s_\\alpha}\n",
+    "$$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "0acc16b5-d2da-446d-aac9-56e8aae6a0e6",
    "metadata": {},
    "source": [


### PR DESCRIPTION
We do not need to track initial assets provided for Omnipool AMM calculations, but we may need to do so for other reasons (like liquidity mining).

I have added the equation for updating the initial assets provided in an LP position to the spec, in case of partial liquidity withdrawal.