### PR TITLE
Lp extension

### DIFF
--- a/hydradx/model/amm/agents.py
+++ b/hydradx/model/amm/agents.py
@@ -9,7 +9,8 @@ class Agent:
                  share_prices: dict[str: float] = None,
                  delta_r: dict[str: float] = None,
                  trade_strategy: any = None,
-                 unique_id: str = 'agent'
+                 unique_id: str = 'agent',
+                 nfts: dict[str: any] = None,
                  ):
         """
         holdings should be in the form of:
@@ -29,6 +30,7 @@ class Agent:
         self.trade_strategy = trade_strategy
         self.asset_list = list(self.holdings.keys())
         self.unique_id = unique_id
+        self.nfts = nfts or {}
 
     def __repr__(self):
         precision = 10
@@ -52,7 +54,8 @@ class Agent:
             share_prices={k: v for k, v in self.share_prices.items()},
             delta_r={k: v for k, v in self.delta_r.items()},
             trade_strategy=self.trade_strategy,
-            unique_id=self.unique_id
+            unique_id=self.unique_id,
+            nfts={id: copy.deepcopy(nft) for id, nft in self.nfts.items()}
         )
         copy_self.initial_holdings = {k: v for k, v in self.initial_holdings.items()}
         copy_self.asset_list = [tkn for tkn in self.asset_list]

--- a/hydradx/model/amm/global_state.py
+++ b/hydradx/model/amm/global_state.py
@@ -143,7 +143,7 @@ class GlobalState:
         for share_id in shares:
             # if shares are for a specific asset in a specific pool, get prices according to that pool
             if isinstance(share_id, tuple):
-                pool_id = share_id[0]
+                pool_id = share_id[0].split('_')[0]
                 tkn_id = share_id[1]
                 prices[share_id] = self.pools[pool_id].usd_price(self.pools[pool_id], tkn_id)
 

--- a/hydradx/model/amm/global_state.py
+++ b/hydradx/model/amm/global_state.py
@@ -143,7 +143,7 @@ class GlobalState:
         for share_id in shares:
             # if shares are for a specific asset in a specific pool, get prices according to that pool
             if isinstance(share_id, tuple):
-                pool_id = share_id[0].split('_')[0]
+                pool_id = share_id[0]
                 tkn_id = share_id[1]
                 prices[share_id] = self.pools[pool_id].usd_price(self.pools[pool_id], tkn_id)
 

--- a/hydradx/model/amm/omnipool_amm.py
+++ b/hydradx/model/amm/omnipool_amm.py
@@ -1438,14 +1438,15 @@ def simulate_add_liquidity(
 def simulate_remove_liquidity(
         old_state: OmnipoolState,
         old_agent: Agent,
-        quantity: float,
-        tkn_remove: str
+        quantity: float = None,
+        tkn_remove: str = '',
+        nft_id: str = None
 ) -> tuple[OmnipoolState, Agent]:
     """Compute new state after liquidity removal"""
     new_state = old_state.copy()
     new_agent = old_agent.copy()
 
-    new_state.remove_liquidity(new_agent, quantity, tkn_remove)
+    new_state.remove_liquidity(new_agent, quantity, tkn_remove, nft_id)
     return new_state, new_agent
 
 

--- a/hydradx/model/amm/omnipool_amm.py
+++ b/hydradx/model/amm/omnipool_amm.py
@@ -1547,13 +1547,6 @@ def value_assets(prices: dict, assets: dict) -> float:
     ])
 
 
-def _turn_off_validations(omnipool: OmnipoolState) -> OmnipoolState:
-    new_state = omnipool.copy()
-    new_state.remove_liquidity_volatility_threshold = float('inf')
-    new_state.max_withdrawal_per_block = float('inf')
-    return new_state
-
-
 def cash_out_omnipool(omnipool: OmnipoolState, agent: Agent, prices) -> float:
     """
     return the value of the agent's holdings if they withdraw all liquidity

--- a/hydradx/model/amm/omnipool_amm.py
+++ b/hydradx/model/amm/omnipool_amm.py
@@ -415,7 +415,7 @@ class OmnipoolState(AMM):
             for pool in self.sub_pools.values():
                 if tkn in pool.asset_list:
                     return pool.unique_id
-    
+
     def swap(
             self,
             agent: Agent,
@@ -445,12 +445,12 @@ class OmnipoolState(AMM):
                 buy_quantity=buy_quantity,
                 sell_quantity=sell_quantity
             )
-    
+
         elif tkn_sell == 'LRNA':
             return_val = self.lrna_swap(agent, buy_quantity, -sell_quantity, tkn_buy, modify_imbalance)
         elif tkn_buy == 'LRNA':
             return_val = self.lrna_swap(agent, -sell_quantity, buy_quantity, tkn_sell, modify_imbalance)
-    
+
         elif buy_quantity and not sell_quantity:
             # back into correct delta_Ri, then execute sell
             delta_Ri = self.calculate_sell_from_buy(tkn_buy, tkn_sell, buy_quantity)
@@ -489,7 +489,7 @@ class OmnipoolState(AMM):
 
             if self.liquidity[i] + sell_quantity > 10 ** 12:
                 return self.fail_transaction('Asset liquidity cannot exceed 10 ^ 12.', agent)
-    
+
             # per-block trade limits
             if (
                     -delta_Rj - self.current_block.volume_in[tkn_buy] + self.current_block.volume_out[tkn_buy]
@@ -511,14 +511,14 @@ class OmnipoolState(AMM):
             self.liquidity[j] += -buy_quantity or delta_Rj
             self.lrna['HDX'] += delta_QH
             self.lrna_imbalance += delta_L
-    
+
             if j not in agent.holdings:
                 agent.holdings[j] = 0
             agent.holdings[i] -= delta_Ri
             agent.holdings[j] -= -buy_quantity or delta_Rj
-    
+
             return_val = self
-    
+
         # update oracle
         if tkn_buy in self.current_block.asset_list:
             buy_quantity = old_buy_liquidity - self.liquidity[tkn_buy]
@@ -529,7 +529,7 @@ class OmnipoolState(AMM):
             self.current_block.volume_in[tkn_sell] += sell_quantity
             self.current_block.price[tkn_sell] = self.lrna[tkn_sell] / self.liquidity[tkn_sell]
         return return_val
-    
+
     def lrna_swap(
             self,
             agent: Agent,
@@ -541,7 +541,7 @@ class OmnipoolState(AMM):
         """
         Execute LRNA swap in place (modify and return)
         """
-    
+
         if delta_qa < 0:
             asset_fee = self.asset_fee[tkn].compute()
             if -delta_qa + self.lrna[tkn] <= 0:
@@ -557,7 +557,7 @@ class OmnipoolState(AMM):
 
             self.lrna[tkn] += delta_q
             self.liquidity[tkn] += -delta_ra
-    
+
         elif delta_ra > 0:
             asset_fee = self.asset_fee[tkn].compute()
             if -delta_ra + self.liquidity[tkn] <= 0:
@@ -573,7 +573,7 @@ class OmnipoolState(AMM):
 
             self.lrna[tkn] += delta_q
             self.liquidity[tkn] -= delta_ra
-    
+
         # buying LRNA
         elif delta_qa > 0:
             lrna_fee = self.lrna_fee[tkn].compute()
@@ -587,13 +587,13 @@ class OmnipoolState(AMM):
             self.liquidity[tkn] += -delta_ra
             # if modify_imbalance:
             #     self.lrna_imbalance += - delta_qi * (q + l) / (q + delta_qi) - delta_qi
-    
+
             # we assume, for now, that buying LRNA is only possible when modify_imbalance = False
             lrna_fee_amt = -(delta_qa + delta_qi)
             delta_l = min(-self.lrna_imbalance, lrna_fee_amt)
             self.lrna_imbalance += delta_l
             self.lrna["HDX"] += lrna_fee_amt - delta_l
-    
+
         elif delta_ra < 0:
             lrna_fee = self.lrna_fee[tkn].compute()
             # delta_ri = -delta_ra
@@ -605,16 +605,16 @@ class OmnipoolState(AMM):
             self.liquidity[tkn] -= delta_ra
             # if modify_imbalance:
             #     self.lrna_imbalance += - delta_qi * (q + l) / (q + delta_qi) - delta_qi
-    
+
             # we assume, for now, that buying LRNA is only possible when modify_imbalance = False
             lrna_fee_amt = -(delta_qa + delta_qi)
             delta_l = min(-self.lrna_imbalance, lrna_fee_amt)
             self.lrna_imbalance += delta_l
             self.lrna["HDX"] += lrna_fee_amt - delta_l
-    
+
         else:
             return self.fail_transaction('All deltas are zero.', agent)
-    
+
         if 'LRNA' not in agent.holdings:
             agent.holdings['LRNA'] = 0
         if tkn not in agent.holdings:
@@ -622,9 +622,9 @@ class OmnipoolState(AMM):
 
         agent.holdings['LRNA'] += delta_qa
         agent.holdings[tkn] += delta_ra
-    
+
         return self
-    
+
     def stable_swap(
             self,
             agent: Agent,
@@ -659,7 +659,7 @@ class OmnipoolState(AMM):
                 delta_shares = agent.holdings[sub_pool.unique_id] - agent_shares
                 sub_pool.remove_liquidity(agent, delta_shares, tkn_buy)
                 return self
-    
+
         elif sub_pool_sell_id and tkn_buy in self.asset_list:
             sub_pool: StableSwapPoolState = self.sub_pools[sub_pool_sell_id]
             if sell_quantity:
@@ -687,13 +687,13 @@ class OmnipoolState(AMM):
                     return self.fail_transaction(sub_pool.fail, agent)
                 self.swap(agent, tkn_buy, sub_pool.unique_id, buy_quantity)
                 return self
-    
+
         elif sub_pool_buy_id and tkn_sell in self.asset_list:
             sub_pool: StableSwapPoolState = self.sub_pools[sub_pool_buy_id]
             if buy_quantity:
                 # buy a stableswap asset with an omnipool asset
                 shares_traded = sub_pool.calculate_withdrawal_shares(tkn_buy, buy_quantity)
-    
+
                 # buy shares in the subpool
                 self.swap(agent, tkn_buy=sub_pool.unique_id, tkn_sell=tkn_sell, buy_quantity=shares_traded)
                 if self.fail:
@@ -753,7 +753,7 @@ class OmnipoolState(AMM):
                 )
                 if pool_buy.fail:
                     return self.fail_transaction(pool_buy.fail, agent)
-    
+
                 # if all three parts succeeded, then we're good!
                 return self
             elif sell_quantity:
@@ -806,7 +806,8 @@ class OmnipoolState(AMM):
                 'subpool_shares': self.liquidity[tkn] * tkns_migrate[tkn] / self.liquidity[tkn]
             } for tkn in tkns_migrate
         }
-        new_sub_pool.shares = sum([self.liquidity[tkn] * tkns_migrate[tkn] / self.liquidity[tkn] for tkn in tkns_migrate])
+        new_sub_pool.shares = sum(
+            [self.liquidity[tkn] * tkns_migrate[tkn] / self.liquidity[tkn] for tkn in tkns_migrate])
         self.sub_pools[unique_id] = new_sub_pool
         self.add_token(
             unique_id,
@@ -818,7 +819,7 @@ class OmnipoolState(AMM):
                 for tkn in tkns_migrate
             ])
         )
-    
+
         # remove assets from Omnipool
         for tkn in tkns_migrate:
             self.lrna[tkn] -= self.lrna[tkn] * tkns_migrate[tkn] / self.liquidity[tkn]
@@ -826,7 +827,7 @@ class OmnipoolState(AMM):
             if self.liquidity[tkn] == 0:
                 self.asset_list.remove(tkn)
         return self
-    
+
     def migrate_asset(self, tkn_migrate: str, sub_pool_id: str):
         """
         Move an asset from the Omnipool into a stableswap subpool.
@@ -840,26 +841,26 @@ class OmnipoolState(AMM):
         self.protocol_shares[s] += (
                 self.shares[s] * self.lrna[i] / self.lrna[s] * self.protocol_shares[i] / self.shares[i]
         )
-    
+
         sub_pool.conversion_metrics[i] = {
             'price': self.lrna[i] / self.lrna[s] * sub_pool.shares / self.liquidity[i],
             'old_shares': self.shares[i],
             'omnipool_shares': self.lrna[i] * self.shares[s] / self.lrna[s],
             'subpool_shares': self.lrna[i] * sub_pool.shares / self.lrna[s]
         }
-    
+
         self.shares[s] += self.lrna[i] * self.shares[s] / self.lrna[s]
         self.liquidity[s] += self.lrna[i] * sub_pool.shares / self.lrna[s]
         sub_pool.shares += self.lrna[i] * sub_pool.shares / self.lrna[s]
         self.lrna[s] += self.lrna[i]
-    
+
         # remove asset from omnipool and add it to subpool
         self.lrna[i] = 0
         self.liquidity[i] = 0
         self.asset_list.remove(i)
         sub_pool.asset_list.append(i)
         return self
-    
+
     def migrate_lp(
             self,
             agent: Agent,
@@ -883,10 +884,11 @@ class OmnipoolState(AMM):
                 agent.holdings[old_pool_id] / conversions['old_shares'] * conversions['subpool_shares']
         )
         agent.holdings[old_pool_id] = 0
-    
+
         return self
 
-    def calculate_remove_liquidity(self, agent: Agent, quantity: float = None, tkn_remove: str = None, nft_id: str = None):
+    def calculate_remove_liquidity(self, agent: Agent, quantity: float = None, tkn_remove: str = None,
+                                   nft_id: str = None):
         """
         If quantity is specified and nft_id is specified, remove specified quantity of shares from specified position.
         If quantity is specified and nft_id is unspecified, remove specified quantity of shares from holdings.
@@ -965,20 +967,20 @@ class OmnipoolState(AMM):
         assert quantity <= 0, f"delta_S cannot be positive: {quantity}"
         if tkn_remove not in self.asset_list:
             raise AssertionError(f"Invalid token name: {tkn_remove}")
-    
+
         # determine if they should get some LRNA back as well as the asset they invested
         piq = lrna_price(self, tkn_remove)
         p0 = share_price
         mult = (piq - p0) / (piq + p0)
-    
+
         # Share update
         delta_b = max(mult * quantity, 0)
         delta_s = quantity + delta_b
-    
+
         # Token amounts update
         delta_q = self.lrna[tkn_remove] / self.shares[tkn_remove] * delta_s
         delta_r = delta_q / piq
-    
+
         if piq > p0:  # prevents rounding errors
             delta_qa = -piq * (
                     2 * piq / (piq + p0) * quantity / self.shares[tkn_remove]
@@ -986,21 +988,21 @@ class OmnipoolState(AMM):
             )
         else:
             delta_qa = 0
-    
+
         if hasattr(self, 'withdrawal_fee') and self.withdrawal_fee > 0:
             # calculate withdraw fee
             diff = abs(self.oracles['price'].price[tkn_remove] - piq) / self.oracles['price'].price[tkn_remove]
             fee = max(min(diff, 1), self.min_withdrawal_fee)
-    
+
             delta_r *= 1 - fee
             delta_qa *= 1 - fee
             delta_q *= 1 - fee
-    
+
         # L update: LRNA fees to be burned before they will start to accumulate again
         delta_l = delta_r * piq * self.lrna_imbalance / self.lrna_total
-    
+
         return delta_qa, delta_r, delta_q, delta_s, delta_b, delta_l
-    
+
     def add_liquidity(
             self,
             agent: Agent = None,
@@ -1009,7 +1011,7 @@ class OmnipoolState(AMM):
             nft_id: str = None
     ):
         """Compute new state after liquidity addition"""
-    
+
         if quantity <= 0:
             return self.fail_transaction('Quantity must be non-negative.', agent)
 
@@ -1022,12 +1024,12 @@ class OmnipoolState(AMM):
 
         if nft_id is not None and nft_id in agent.nfts:
             raise AssertionError('Agent already has an NFT with this ID.')
-    
+
         if agent.holdings[tkn_add] < quantity:
             return self.fail_transaction(
                 f'Agent has insufficient funds ({agent.holdings[tkn_add]} < {quantity}).', agent
             )
-    
+
         if (self.lrna[tkn_add] + delta_Q) / (self.lrna_total + delta_Q) > self.weight_cap[tkn_add]:
             return self.fail_transaction(
                 'Transaction rejected because it would exceed the weight cap in pool[{i}].', agent
@@ -1036,7 +1038,7 @@ class OmnipoolState(AMM):
         if self.tvl_cap < float('inf'):
             if (self.total_value_locked() + quantity * usd_price(self, tkn_add)) > self.tvl_cap:
                 return self.fail_transaction('Transaction rejected because it would exceed the TVL cap.', agent)
-    
+
         # assert quantity > 0, f"delta_R must be positive: {quantity}"
         if tkn_add not in self.asset_list:
             for sub_pool in self.sub_pools.values():
@@ -1063,7 +1065,7 @@ class OmnipoolState(AMM):
                 return self.fail_transaction(
                     'Transaction rejected because it would exceed the max LP per block.', agent
                 )
-    
+
         # Share update
         if self.shares[tkn_add]:
             shares_added = (delta_Q / self.lrna[tkn_add]) * self.shares[tkn_add]
@@ -1074,10 +1076,10 @@ class OmnipoolState(AMM):
         # L update: LRNA fees to be burned before they will start to accumulate again
         delta_L = quantity * lrna_price(self, tkn_add) * self.lrna_imbalance / self.lrna_total
         self.lrna_imbalance += delta_L
-    
+
         # LRNA add (mint)
         self.lrna[tkn_add] += delta_Q
-    
+
         # Token amounts update
         self.liquidity[tkn_add] += quantity
 
@@ -1092,14 +1094,15 @@ class OmnipoolState(AMM):
             agent.share_prices[k] = lrna_price(self, tkn_add)
             agent.delta_r[k] = quantity
         else:
-            lp_position = OmnipoolLiquidityPosition(tkn_add, lrna_price(self, tkn_add), shares_added, quantity, self.unique_id)
+            lp_position = OmnipoolLiquidityPosition(tkn_add, lrna_price(self, tkn_add), shares_added, quantity,
+                                                    self.unique_id)
             agent.nfts[nft_id] = lp_position
-    
+
         # update block
         self.current_block.lps[tkn_add] += quantity
-    
+
         return self
-    
+
     def remove_liquidity(self, agent: Agent, quantity: float = None, tkn_remove: str = '', nft_id: str = None):
         """
         Remove liquidity from a sub pool.
@@ -1130,7 +1133,7 @@ class OmnipoolState(AMM):
                         return self.fail_transaction(sub_pool.fail, agent)
                     else:
                         return self
-    
+
             raise AssertionError(f"invalid value for tkn_remove: {tkn_remove}")
 
         if quantity == 0:
@@ -1149,7 +1152,7 @@ class OmnipoolState(AMM):
                 return self.fail_transaction('Specified position is wrong asset.', agent)
             elif quantity is not None and agent.nfts[nft_id].shares < quantity:
                 return self.fail_transaction('Agent does not have enough shares in specified position.', agent)
-    
+
         if self.remove_liquidity_volatility_threshold and self.remove_liquidity_volatility_threshold < float('inf'):
             if self.oracles['price']:
                 volatility = abs(
@@ -1171,12 +1174,13 @@ class OmnipoolState(AMM):
         )
         if abs(delta_s) > max_remove:
             return self.fail_transaction(
-                f"Transaction rejected because it would exceed the withdrawal limit: {abs(delta_s)} > {max_remove}", agent
+                f"Transaction rejected because it would exceed the withdrawal limit: {abs(delta_s)} > {max_remove}",
+                agent
             )
 
         if delta_r + self.liquidity[tkn_remove] < 0:
             return self.fail_transaction('Cannot remove more liquidity than exists in the pool.', agent)
-    
+
         self.liquidity[tkn_remove] += delta_r
         self.shares[tkn_remove] += delta_s
         self.protocol_shares[tkn_remove] += delta_b
@@ -1213,7 +1217,8 @@ class OmnipoolState(AMM):
         self.current_block.withdrawals[tkn_remove] += abs(delta_s)
         return self
 
-    def value_assets(self, assets: dict[str, float], equivalency_map: dict[str, str] = None, stablecoin: str = None) -> float:
+    def value_assets(self, assets: dict[str, float], equivalency_map: dict[str, str] = None,
+                     stablecoin: str = None) -> float:
         # assets is a dict of token: quantity
         # returns the value of the assets in USD
         if stablecoin is None:
@@ -1257,7 +1262,6 @@ class OmnipoolLiquidityPosition:
 
     def copy(self):
         return OmnipoolLiquidityPosition(self.tkn, self.price, self.shares, self.delta_r, self.pool_id)
-
 
 
 class OmnipoolArchiveState:

--- a/hydradx/model/amm/omnipool_amm.py
+++ b/hydradx/model/amm/omnipool_amm.py
@@ -1590,15 +1590,16 @@ def cash_out_omnipool(omnipool: OmnipoolState, agent: Agent, prices) -> float:
     lrna_removed = {tkn: -delta_q[tkn] if tkn in delta_q else 0 for tkn in omnipool.asset_list}
     liquidity_removed = {tkn: -delta_r[tkn] if tkn in delta_r else 0 for tkn in omnipool.asset_list}
 
-    if 'LRNA' in prices:
-        raise ValueError('LRNA price should not be given.')
-    lrna_to_sell = delta_qa
+    # if 'LRNA' in prices:
+    #     raise ValueError('LRNA price should not be given.')
+    agent_lrna = delta_qa
     if 'LRNA' in agent.holdings:
-        lrna_to_sell += agent.holdings['LRNA']
-    if 'LRNA' not in prices and lrna_to_sell > 0:
+        agent_lrna += agent.holdings['LRNA']
+
+    if 'LRNA' not in prices and agent_lrna > 0:
         lrna_total = omnipool.lrna_total - sum(lrna_removed.values())
         lrna_sells = {
-            tkn: -(omnipool.lrna[tkn] - lrna_removed[tkn]) / lrna_total * lrna_to_sell
+            tkn: -(omnipool.lrna[tkn] - lrna_removed[tkn]) / lrna_total * agent_lrna
             for tkn in omnipool.asset_list
         }
 
@@ -1619,6 +1620,7 @@ def cash_out_omnipool(omnipool: OmnipoolState, agent: Agent, prices) -> float:
             liquidity_removed[tkn] += lrna_profits[tkn]
 
     new_holdings = {tkn: agent.holdings[tkn] for tkn in agent.holdings}
+    new_holdings['LRNA'] = agent_lrna
     for tkn in liquidity_removed:
         if tkn not in new_holdings:
             new_holdings[tkn] = 0

--- a/hydradx/model/amm/omnipool_amm.py
+++ b/hydradx/model/amm/omnipool_amm.py
@@ -886,29 +886,6 @@ class OmnipoolState(AMM):
     
         return self
 
-    # def calculate_remove_all_liquidity(self, agent: Agent, tkn_remove):
-    #     delta_qa, delta_r, delta_q, delta_s, delta_b, delta_l = 0, 0, 0, 0, 0, 0
-    #     for k in agent.holdings:
-    #         if len(k) > 1 and k[1] == tkn_remove:
-    #             k_split = k[0].split("_")
-    #             if len(k_split) == 1:
-    #                 qa, r, q, s, b, l = self.calculate_remove_liquidity(agent, agent.holdings[k], tkn_remove)
-    #                 delta_qa += qa
-    #                 delta_r += r
-    #                 delta_q += q
-    #                 delta_s += s
-    #                 delta_b += b
-    #                 delta_l += l
-    #             elif k_split[0] == self.unique_id:
-    #                 qa, r, q, s, b, l = self.calculate_remove_liquidity(agent, agent.holdings[k], tkn_remove, int(k_split[1]))
-    #                 delta_qa += qa
-    #                 delta_r += r
-    #                 delta_q += q
-    #                 delta_s += s
-    #                 delta_b += b
-    #                 delta_l += l
-    #     return delta_qa, delta_r, delta_q, delta_s, delta_b, delta_l
-
     def calculate_remove_liquidity(self, agent: Agent, quantity: float = None, tkn_remove: str = None, nft_id: str = None):
         """
         If quantity is specified and nft_id is specified, remove specified quantity of shares from specified position.

--- a/hydradx/model/amm/omnipool_amm.py
+++ b/hydradx/model/amm/omnipool_amm.py
@@ -1099,17 +1099,6 @@ class OmnipoolState(AMM):
         self.current_block.lps[tkn_add] += quantity
     
         return self
-
-    # def remove_all_liquidity(self, agent: Agent, tkn_remove: str):
-    #     agent_assets = list(agent.holdings.keys())
-    #     for k in agent_assets:
-    #         if len(k) > 1 and k[1] == tkn_remove:
-    #             k_split = k[0].split("_")
-    #             if len(k_split) == 1:
-    #                 self.remove_liquidity(agent, agent.holdings[k], tkn_remove)
-    #             elif k[0].split("_")[0] == self.unique_id:
-    #                 self.remove_liquidity(agent, agent.holdings[k], tkn_remove, int(k[0].split("_")[1]))
-    #     return self
     
     def remove_liquidity(self, agent: Agent, quantity: float = None, tkn_remove: str = '', nft_id: str = None):
         """

--- a/hydradx/model/amm/omnipool_amm.py
+++ b/hydradx/model/amm/omnipool_amm.py
@@ -1149,6 +1149,10 @@ class OmnipoolState(AMM):
         #     k = (self.unique_id + "_" + str(i), tkn_remove)
 
         k = (self.unique_id, tkn_remove)
+        if nft_id is not None:
+            if nft_id not in agent.nfts:
+                return self.fail_transaction('Agent does not have liquidity position with specified nft_id.', agent)
+            tkn_remove = agent.nfts[nft_id].tkn
 
         if tkn_remove not in self.asset_list:
             for sub_pool in self.sub_pools.values():
@@ -1161,7 +1165,7 @@ class OmnipoolState(AMM):
                     else:
                         return self
     
-            raise AssertionError(f"invalid value for i: {tkn_remove}")
+            raise AssertionError(f"invalid value for tkn_remove: {tkn_remove}")
 
         if quantity == 0:
             return self

--- a/hydradx/model/amm/omnipool_amm.py
+++ b/hydradx/model/amm/omnipool_amm.py
@@ -947,9 +947,26 @@ class OmnipoolState(AMM):
                     if isinstance(nft, OmnipoolLiquidityPosition):
                         if nft.pool_id == self.unique_id and nft.tkn == tkn_remove:
                             nft_ids.append(nft_id)
-                            delta_qa, delta_r, delta_q, delta_s, delta_b, delta_l = self._calculate_remove_one_position(
+                            dqa, dr, dq, ds, db, dl = self._calculate_remove_one_position(
                                 quantity=nft.shares, tkn_remove=tkn_remove, share_price=nft.price
                             )
+                            delta_qa += dqa
+                            delta_r += dr
+                            delta_q += dq
+                            delta_s += ds
+                            delta_b += db
+                            delta_l += dl
+                if (self.unique_id, tkn_remove) in agent.holdings:
+                    dqa, dr, dq, ds, db, dl = self._calculate_remove_one_position(
+                        quantity=agent.holdings[(self.unique_id, tkn_remove)], tkn_remove=tkn_remove,
+                        share_price=agent.share_prices[(self.unique_id, tkn_remove)]
+                    )
+                    delta_qa += dqa
+                    delta_r += dr
+                    delta_q += dq
+                    delta_s += ds
+                    delta_b += db
+                    delta_l += dl
         return delta_qa, delta_r, delta_q, delta_s, delta_b, delta_l, nft_ids
 
     def _calculate_remove_one_position(self, quantity, tkn_remove, share_price):

--- a/hydradx/model/amm/omnipool_amm.py
+++ b/hydradx/model/amm/omnipool_amm.py
@@ -906,7 +906,7 @@ class OmnipoolState(AMM):
         if quantity is not None:
             if nft_id is None:  # remove specified quantity of shares from holdings
                 k = (self.unique_id, tkn_remove)
-                return self._calculate_remove_one_position(
+                delta_qa, delta_r, delta_q, delta_s, delta_b, delta_l = self._calculate_remove_one_position(
                     quantity=quantity, tkn_remove=tkn_remove, share_price=agent.share_prices[k]
                 )
             else:  # remove specified quantity of shares from specified position

--- a/hydradx/model/amm/trade_strategies.py
+++ b/hydradx/model/amm/trade_strategies.py
@@ -1031,26 +1031,13 @@ def dca_with_lping(
             sell_quantity=agent.holdings[sell_asset] - init_sell_amt
         )
 
-        # we turn off the withdrawal fee for this remove_liquidity
-        # this is because removing liquidity here is due to a limitation in our implementation,
-        # agents can have only one LP position each in one asset in Omnipool.
-        # In reality someone executing this strategy would simply add liquidity and get a new LP position.
-        withdrawal_fee_cache = pool.withdrawal_fee  # hack to temporarily zero out withdrawal fee
-        pool.withdrawal_fee = False
-        if agent.is_holding((pool.unique_id, buy_asset)):
-            # remove all liquidity in buy_asset
-            pool.remove_liquidity(
-                agent=agent,
-                quantity=agent.holdings[(pool.unique_id, buy_asset)],
-                tkn_remove=buy_asset
-            )
-        pool.withdrawal_fee = withdrawal_fee_cache
-
         # LP the buy asset
+        nft_id = str(len(agent.nfts) + 1)
         pool.add_liquidity(
             agent=agent,
             quantity=agent.holdings[buy_asset] - init_buy_amt,
-            tkn_add=buy_asset
+            tkn_add=buy_asset,
+            nft_id=nft_id
         )
 
         return state

--- a/hydradx/tests/test_liquidations.py
+++ b/hydradx/tests/test_liquidations.py
@@ -713,7 +713,7 @@ def test_liquidate_against_omnipool_fuzz(collateral_amt1: float, ratio1: float, 
     if cdp1.debt_amt == 0:  # fully liquidated
         assert ratio1 >= full_liq_threshold
     elif cdp1.collateral_amt == 0:  # fully liquidated, bad debt remaining
-        assert ratio1 > 1
+        assert ratio1 > 1/(1 + mm.liquidation_penalty['DOT'])
     elif cdp1.debt_amt == debt_amt1:  # not liquidated
         if ratio1 < liq_threshold:  # 1. overcollateralized
             pass

--- a/hydradx/tests/test_omnipool_agents.py
+++ b/hydradx/tests/test_omnipool_agents.py
@@ -238,10 +238,8 @@ def test_dca_with_lping(
     strategy.execute(state, trader_id)
 
     if init_sell_tkn_lped > 0:
-        if ('omnipool', buy_tkn) not in agent.holdings:
+        if len(agent.nfts) == 0:
             raise AssertionError('Agent does not have shares for buy_tkn.')
-        if agent.holdings[('omnipool', buy_tkn)] == init_buy_tkn_lped:
-            raise AssertionError('Agent did not receive shares for buy_tkn.')
 
         lp_diff = init_sell_tkn_lped
         if ('omnipool', sell_tkn) in agent.holdings:

--- a/hydradx/tests/test_omnipool_amm.py
+++ b/hydradx/tests/test_omnipool_amm.py
@@ -616,52 +616,6 @@ def test_remove_liquidity_no_fee_different_price(initial_state: oamm.OmnipoolSta
         raise AssertionError(f'LRNA imbalance did not remain constant.')
 
 
-@given(st.integers(min_value=1, max_value=2))
-def test_remove_liquidity_one_of_two(n):
-
-    liquidity = {'HDX': mpf(10000000), 'USD': mpf(1000000), 'DOT': mpf(100000)}
-    lrna = {'HDX': mpf(1000000), 'USD': mpf(1000000), 'DOT': mpf(1000000)}
-    initial_state = oamm.OmnipoolState(
-        tokens={
-            tkn: {'liquidity': liquidity[tkn], 'LRNA': lrna[tkn]} for tkn in lrna
-        }
-    )
-    tkn = 'DOT'
-    holdings = {
-        tkn: initial_state.liquidity[tkn],
-        (initial_state.unique_id, tkn): initial_state.shares[tkn] / 10,
-        (initial_state.unique_id + '_1', tkn): initial_state.shares[tkn] / 10
-    }
-    share_prices = {(initial_state.unique_id, tkn): 8, (initial_state.unique_id + '_1', tkn): 12}
-    init_agent = Agent(holdings=holdings, share_prices=share_prices)
-    if n == 0:
-        k = (initial_state.unique_id, tkn)
-        k2 = (initial_state.unique_id + '_1', tkn)  #TODO fix this
-    else:
-        k = (initial_state.unique_id + '_1', tkn)
-        k2 = (initial_state.unique_id, tkn)
-
-    quantity = init_agent.holdings[k]
-
-    comp_holdings = {k: v for k, v in holdings.items()}
-    del comp_holdings[k2]
-    comp_prices = {k: v for k, v in share_prices.items()}
-    del comp_prices[k2]
-    comp_agent = Agent(holdings=comp_holdings, share_prices=comp_prices)
-
-    agent = init_agent.copy()
-    pool = initial_state.copy()
-    comp_pool = initial_state.copy()
-    if n == 0:
-        pool.remove_liquidity(agent, quantity, tkn)
-        comp_pool.remove_liquidity(comp_agent, quantity, tkn)
-    else:
-        pool.remove_liquidity(agent, quantity, tkn, n)
-        comp_pool.remove_liquidity(comp_agent, quantity, tkn, n)
-
-    assert pool.liquidity[tkn] == comp_pool.liquidity[tkn]
-
-
 @given(st.floats(min_value=1, max_value=100),
 st.floats(min_value=0.1, max_value=0.9))
 def test_remove_liquidity_split(price: float, split: float):
@@ -681,7 +635,6 @@ def test_remove_liquidity_split(price: float, split: float):
     prices1 = {(initial_state.unique_id, tkn): price}
     agent1 = Agent(holdings=holdings1, share_prices=prices1)
 
-    # holdings2 = {(initial_state.unique_id, tkn): amt2, (initial_state.unique_id + '_1', tkn): amt3}
     nft1 = OmnipoolLiquidityPosition(tkn, price, amt2, 0, initial_state.unique_id)
     nft2 = OmnipoolLiquidityPosition(tkn, price, amt3, 0, initial_state.unique_id)
     nfts = {'nft001': nft1, 'nft002': nft2}

--- a/hydradx/tests/test_omnipool_amm.py
+++ b/hydradx/tests/test_omnipool_amm.py
@@ -239,41 +239,6 @@ def test_compare_several_lp_adds_to_single(n):
         raise AssertionError(f'Adding liquidity in one go should be equivalent to adding it in {n} steps.')
 
 
-# TODO adjust these tests using nft_id input
-
-
-# def test_add_additional_positions_at_new_price():
-#     liquidity = {'HDX': mpf(10000000), 'USD': mpf(1000000), 'DOT': mpf(100000)}
-#     lrna = {'HDX': mpf(1000000), 'USD': mpf(1000000), 'DOT': mpf(1000000)}
-#     initial_state = oamm.OmnipoolState(
-#         tokens={
-#             tkn: {'liquidity': liquidity[tkn], 'LRNA': lrna[tkn]} for tkn in lrna
-#         }
-#     )
-#     tkn = 'DOT'
-#     holdings = {tkn: initial_state.liquidity[tkn], (initial_state.unique_id, tkn): initial_state.shares[tkn] / 10}
-#     share_prices = {(initial_state.unique_id, tkn): 8}
-#     init_agent = Agent(holdings=holdings, share_prices=share_prices)
-#     delta_R = init_agent.holdings[tkn] / 2
-#
-#     new_state, new_agent = oamm.simulate_add_liquidity(initial_state, init_agent, delta_R, tkn)
-#
-#     if new_agent.holdings[(initial_state.unique_id, tkn)] != init_agent.holdings[(initial_state.unique_id, tkn)]:
-#         raise AssertionError(f'Adding liquidity should not change the shares in existing position')
-#     if new_agent.share_prices[(initial_state.unique_id, tkn)] != init_agent.share_prices[(initial_state.unique_id, tkn)]:
-#         raise AssertionError(f'Adding liquidity should not change the share price in existing position')
-#     if new_agent.share_prices[(initial_state.unique_id + '_1', tkn)] != initial_state.price(initial_state, tkn):
-#         raise AssertionError(f'Adding liquidity should set the share price in new position to the pool price')
-#
-#     new_state2, new_agent2 = oamm.simulate_add_liquidity(new_state, new_agent, delta_R, tkn)
-#     if new_agent2.holdings[(initial_state.unique_id + '_1', tkn)] != new_agent.holdings[(initial_state.unique_id + '_1', tkn)]:
-#         raise AssertionError(f'Adding liquidity should not change the shares in existing position')
-#     if new_agent2.share_prices[(initial_state.unique_id, tkn)] != new_agent.share_prices[(initial_state.unique_id, tkn)]:
-#         raise AssertionError(f'Adding liquidity should not change the share price in existing position')
-#     if new_agent2.share_prices[(initial_state.unique_id + '_1', tkn)] != new_state.price(initial_state, tkn):
-#         raise AssertionError(f'Adding liquidity should set the share price in new position to the pool price')
-
-
 @settings(max_examples=1)
 @given(omnipool_config(token_count=3, lrna_fee=0, asset_fee=0))
 def test_add_liquidity_with_quantity_zero_should_fail(initial_state: oamm.OmnipoolState):

--- a/hydradx/tests/test_omnipool_amm.py
+++ b/hydradx/tests/test_omnipool_amm.py
@@ -417,7 +417,32 @@ def test_remove_liquidity_specified_quantity_unspecified_nft(price_mult: float):
     if not new_state.fail:
         raise AssertionError(f'Removing liquidity with quantity greater than holdings should fail.')
 
+@given(st.floats(min_value=0.1, max_value=10))
+def test_remove_liquidity_unspecified_quantity_specified_nft(price_mult: float):
+    liquidity = {'HDX': mpf(10000000), 'USD': mpf(1000000), 'DOT': mpf(100000)}
+    lrna = {'HDX': mpf(1000000), 'USD': mpf(1000000), 'DOT': mpf(1000000)}
+    initial_state = oamm.OmnipoolState(
+        tokens={
+            tkn: {'liquidity': liquidity[tkn], 'LRNA': lrna[tkn]} for tkn in lrna
+        }
+    )
+    tkn = 'DOT'
 
+    p = price_mult * initial_state.price(initial_state, tkn, 'LRNA')
+    s = initial_state.shares[tkn] / 10
+    position = OmnipoolLiquidityPosition(tkn, p, s, 0, initial_state.unique_id)
+    init_agent = Agent(nfts={'position': position})
+
+    new_state, new_agent = oamm.simulate_remove_liquidity(initial_state, init_agent, tkn_remove=tkn, nft_id='position')
+    comp_state, comp_agent = oamm.simulate_remove_liquidity(initial_state, init_agent, s, tkn, 'position')
+    if new_state.liquidity[tkn] != pytest.approx(comp_state.liquidity[tkn], rel=1e-20):
+        raise AssertionError(f'Remaining liquidity doesn\'t match.')
+    if new_state.shares[tkn] != pytest.approx(comp_state.shares[tkn], rel=1e-20):
+        raise AssertionError(f'Remaining shares doesn\'t match.')
+    if new_state.lrna[tkn] != pytest.approx(comp_state.lrna[tkn], rel=1e-20):
+        raise AssertionError(f'Remaining LRNA doesn\'t match.')
+    if new_state.protocol_shares[tkn] != pytest.approx(comp_state.protocol_shares[tkn], rel=1e-20):
+        raise AssertionError(f'Remaining protocol shares doesn\'t match.')
 
 
 @given(omnipool_config(token_count=3, withdrawal_fee=False))

--- a/hydradx/tests/test_omnipool_amm.py
+++ b/hydradx/tests/test_omnipool_amm.py
@@ -3127,17 +3127,19 @@ def test_cash_out_multiple_positions(trade_sizes: list[float]):
         withdrawal_fee=False
     )
 
-    lp_quantity = 10000
+    lp_quantity = mpf(10000)
     agent1 = Agent(holdings={'DOT': lp_quantity * len(trade_sizes)})
-    agent2 = Agent(holdings={'DOT': 10000000, 'HDX': 10000000})
+    agent2 = Agent(holdings={'DOT': mpf(10000000), 'HDX': mpf(10000000)})
     for i, trade in enumerate(trade_sizes):
         initial_state.add_liquidity(agent1, tkn_add='DOT', quantity=lp_quantity, nft_id=str(i))
         if trade > 0:
-            initial_state.swap(agent2, tkn_buy='HDX', tkn_sell='DOT', sell_quantity=trade)
-        else:
-            initial_state.swap(agent2, tkn_buy='DOT', tkn_sell='HDX', sell_quantity=-trade)
+            initial_state.swap(agent2, tkn_buy='HDX', tkn_sell='DOT', sell_quantity=mpf(trade))
+        elif trade < 0:
+            initial_state.swap(agent2, tkn_buy='DOT', tkn_sell='HDX', sell_quantity=-mpf(trade))
 
     spot_prices = {tkn: initial_state.price(initial_state, tkn, 'USD') for tkn in initial_state.asset_list}
+    spot_prices['LRNA'] = oamm.usd_price(initial_state, 'LRNA')
+
     cash_out_value = cash_out_omnipool(initial_state, agent1, spot_prices)
     cash_out_state = initial_state.copy()
     cash_out_agent = agent1.copy()

--- a/hydradx/tests/test_omnipool_amm.py
+++ b/hydradx/tests/test_omnipool_amm.py
@@ -3121,14 +3121,15 @@ def test_cash_out_multiple_positions_works_with_lrna(price1: float, price2: floa
     tkn = 'DOT'
     amt1 = r * initial_state.shares[tkn] / 5
     amt2 = initial_state.shares[tkn] / 5 - amt1
-    holdings1 = {(initial_state.unique_id, tkn): amt1, (initial_state.unique_id + '_1', tkn): amt2}
-    prices1 = {(initial_state.unique_id, tkn): price1, (initial_state.unique_id + '_1', tkn): price2}
-    agent = Agent(holdings=holdings1, share_prices=prices1)
+    holdings1 = {(initial_state.unique_id, tkn): amt1}
+    prices1 = {(initial_state.unique_id, tkn): price1}
+    nft = OmnipoolLiquidityPosition(tkn, price2, amt2, 0, initial_state.unique_id)
+    agent = Agent(holdings=holdings1, share_prices=prices1, nfts={'pos1': nft})
     spot_prices = {tkn: initial_state.price(initial_state, tkn, 'USD') for tkn in initial_state.asset_list}
     cash_out = cash_out_omnipool(initial_state, agent, spot_prices)
 
     state = initial_state.copy()
-    state.remove_all_liquidity(agent, tkn)
+    state.remove_liquidity(agent, tkn_remove=tkn)
     dot_value = agent.holdings['DOT'] * spot_prices['DOT']
     lrna_value = agent.holdings['LRNA'] * initial_state.price(initial_state, 'LRNA', 'USD')
     assert dot_value < cash_out < dot_value + lrna_value  # cash_out will be less than dot + lrna due to slippage

--- a/hydradx/tests/test_omnipool_amm.py
+++ b/hydradx/tests/test_omnipool_amm.py
@@ -211,11 +211,13 @@ def test_compare_several_lp_adds_to_single(n):
     delta_R = init_agent.holdings[tkn] / 2
 
     single_add_state_1, single_add_agent_1 = oamm.simulate_add_liquidity(initial_state, init_agent, delta_R, tkn)
-    single_add_state_2, single_add_agent_2 = oamm.simulate_add_liquidity(initial_state, init_agent, delta_R, tkn, nft_id="id001")
+    single_add_state_2, single_add_agent_2 = oamm.simulate_add_liquidity(initial_state, init_agent, delta_R, tkn,
+                                                                         nft_id="id001")
     multi_add_state, multi_add_agent = initial_state, init_agent
     for i in range(n):
         nft_id = str(i)
-        multi_add_state, multi_add_agent = oamm.simulate_add_liquidity(multi_add_state, multi_add_agent, delta_R / n, tkn, nft_id=nft_id)
+        multi_add_state, multi_add_agent = oamm.simulate_add_liquidity(multi_add_state, multi_add_agent, delta_R / n,
+                                                                       tkn, nft_id=nft_id)
 
     if single_add_state_1.liquidity[tkn] != pytest.approx(multi_add_state.liquidity[tkn], rel=1e-20):
         raise AssertionError(f'Adding liquidity in one go should be equivalent to adding it in {n} steps.')
@@ -382,6 +384,7 @@ def test_remove_liquidity_specified_quantity_unspecified_nft(price_mult: float):
     if not new_state.fail:
         raise AssertionError(f'Removing liquidity with quantity greater than holdings should fail.')
 
+
 @given(st.floats(min_value=0.1, max_value=10))
 def test_remove_liquidity_unspecified_quantity_specified_nft(price_mult: float):
     liquidity = {'HDX': mpf(10000000), 'USD': mpf(1000000), 'DOT': mpf(100000)}
@@ -409,6 +412,7 @@ def test_remove_liquidity_unspecified_quantity_specified_nft(price_mult: float):
     if new_state.protocol_shares[tkn] != pytest.approx(comp_state.protocol_shares[tkn], rel=1e-20):
         raise AssertionError(f'Remaining protocol shares doesn\'t match.')
 
+
 @given(st.floats(min_value=0.1, max_value=10))
 def test_remove_liquidity_unspecified_quantity_unspecified_nft(price_mult: float):
     liquidity = {'HDX': mpf(10000000), 'USD': mpf(1000000), 'DOT': mpf(100000)}
@@ -422,9 +426,9 @@ def test_remove_liquidity_unspecified_quantity_unspecified_nft(price_mult: float
 
     p = price_mult * initial_state.price(initial_state, tkn, 'LRNA')
     s = initial_state.shares[tkn] / 10
-    holdings = {(initial_state.unique_id, tkn): s/2}
+    holdings = {(initial_state.unique_id, tkn): s / 2}
     share_prices = {(initial_state.unique_id, tkn): p}
-    position = OmnipoolLiquidityPosition(tkn, p, s/2, 0, initial_state.unique_id)
+    position = OmnipoolLiquidityPosition(tkn, p, s / 2, 0, initial_state.unique_id)
     init_agent = Agent(holdings=holdings, share_prices=share_prices, nfts={'position': position})
 
     position = OmnipoolLiquidityPosition(tkn, p, s, 0, initial_state.unique_id)
@@ -617,7 +621,7 @@ def test_remove_liquidity_no_fee_different_price(initial_state: oamm.OmnipoolSta
 
 
 @given(st.floats(min_value=1, max_value=100),
-st.floats(min_value=0.1, max_value=0.9))
+       st.floats(min_value=0.1, max_value=0.9))
 def test_remove_liquidity_split(price: float, split: float):
     liquidity = {'HDX': mpf(10000000), 'USD': mpf(1000000), 'DOT': mpf(100000)}
     lrna = {'HDX': mpf(1000000), 'USD': mpf(1000000), 'DOT': mpf(1000000)}
@@ -1666,7 +1670,6 @@ def test_dynamic_fees_with_trade(liquidity: list[float], lrna: list[float], orac
                                  oracle_volume_in: list[float], oracle_volume_out: list[float],
                                  oracle_prices: list[float], n, trade_size: float, lrna_fees: list[float],
                                  asset_fees: list[float], amp: list[float], decay: list[float]):
-
     init_liquidity = {
         'HDX': {'liquidity': liquidity[0], 'LRNA': lrna[0]},
         'USD': {'liquidity': liquidity[1], 'LRNA': lrna[1]},
@@ -2759,7 +2762,8 @@ def test_calculate_buy_from_sell(omnipool: oamm.OmnipoolState):
     usd_lrna_fee=st.floats(min_value=0, max_value=0.1)
 )
 def test_buy_sell_spot(
-        hdx_lrna: float, usd_lrna: float, hdx_asset_fee: float, hdx_lrna_fee: float, usd_asset_fee: float, usd_lrna_fee: float
+        hdx_lrna: float, usd_lrna: float, hdx_asset_fee: float, hdx_lrna_fee: float, usd_asset_fee: float,
+        usd_lrna_fee: float
 ):
     tokens = {
         'HDX': {'liquidity': mpf(1000000000), 'LRNA': hdx_lrna},

--- a/hydradx/tests/test_omnipool_state.py
+++ b/hydradx/tests/test_omnipool_state.py
@@ -311,7 +311,7 @@ def test_cash_out_accuracy(omnipool: oamm.OmnipoolState, share_price_ratio, lp_i
             )
             lrna_profits[tkn] = withdraw_agent.holdings[tkn] - agent_holdings
 
-    del withdraw_agent.holdings['LRNA']
+        del withdraw_agent.holdings['LRNA']
     cash_count = sum([market_prices[tkn] * withdraw_agent.holdings[tkn] for tkn in withdraw_agent.holdings])
     if cash_count != pytest.approx(cash_out, rel=1e-15):
         raise AssertionError('Cash out calculation is not accurate.')

--- a/hydradx/tests/test_stableswap.py
+++ b/hydradx/tests/test_stableswap.py
@@ -459,6 +459,7 @@ def test_exploitability(initial_lp: int, trade_size: int):
             break
 
 
+@settings(deadline=timedelta(milliseconds=500))
 @given(
     st.integers(min_value=1, max_value=1000000),
     st.floats(min_value=0.00001, max_value=0.99999)


### PR DESCRIPTION
Adds the ability for LPs to have multiple LP positions in Omnipool in the same asset, by making LP positions NFTs. Backward compatible so that LP positions can still be represented by (pool_name, tkn_name) assets in agent holdings.